### PR TITLE
Simhasher中的extract调用jieba库KeywordExtractor中的Extract函数冲突

### DIFF
--- a/include/simhash/Simhasher.hpp
+++ b/include/simhash/Simhasher.hpp
@@ -20,7 +20,8 @@ namespace simhash
 
             bool extract(const string& text, vector<pair<string,double> > & res, size_t topN) const
             {
-                return _extractor.Extract(text, res, topN);
+                _extractor.Extract(text, res, topN);
+                return true;
             }
             bool make(const string& text, size_t topN, vector<pair<uint64_t, double> >& res) const
             {


### PR DESCRIPTION
在使用Simhasher调用jieba库KeywordExtractor中的Extract函数时，Extract返回值是void,但是在Simhasher.hpp中的`bool extract(const string& text, vector<pair<string,double> > & res, size_t topN) const
            {
               return _extractor.Extract(text, res, topN);
            }`
函数中用来返回了一个bool值，产生了报错