### PR TITLE
Cover latest GitHub-hosted runners in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,7 @@ jobs:
         build_type: [Release, Debug]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
         fetch-depth: 0

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,17 +12,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 
-          ubuntu-22.04, 
-          ubuntu-24.04, 
-          macos-14,
-          windows-2022,
-        ]  
+        os:
+          - ubuntu-22.04
+          - ubuntu-latest
+          - macos-14
+          - macos-latest
+          - windows-2022
+          - windows-latest
         cpp_version: [11, 14, 17, 20]
         build_type: [Release, Debug]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
         fetch-depth: 0


### PR DESCRIPTION
## Summary
- add `ubuntu-latest`, `macos-latest`, and `windows-latest` to the CMake matrix
- keep explicit baseline runners (`ubuntu-22.04`, `macos-14`, `windows-2022`)
- update `actions/checkout` to v6

## Context
- GitHub-hosted runner labels currently map `ubuntu-latest` to Ubuntu 24.04, `windows-latest` to Windows Server 2025, and `macos-latest` to macOS 15 arm64.

## Testing
- Not run locally; workflow-only change.