### PR TITLE
[codex] Add macOS 26 CI coverage

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,6 +17,7 @@ jobs:
           - ubuntu-latest
           - macos-14
           - macos-latest
+          - macos-26
           - windows-2022
           - windows-latest
         cpp_version: [11, 14, 17, 20]


### PR DESCRIPTION
## Summary

- Add `macos-26` to the CMake workflow OS matrix.
- Keep existing Ubuntu, Windows, macOS 14, and `macos-latest` coverage.

## Rationale

GitHub-hosted runners now include macOS 26 labels, so this expands routine compatibility coverage to the latest available macOS runner image.

## Validation

- Workflow-only change; validation is the pull request CMake matrix.